### PR TITLE
If the download_addr is missing for a video, use the play_addr instead

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -170,11 +170,24 @@ const getVideo = async (url, watermark) => {
             // url_list[1] contains a jpeg
             image_urls.push(element.display_image.url_list[1]);
         });
+        } else if (res.aweme_list[0].video) {
+        urlMedia = null;
+        const video = res.aweme_list[0].video;
+        if (watermark){
+            if(video.download_addr && video.download_addr.url_list && video.download_addr.url_list.length > 0){
+                urlMedia = video.download_addr.url_list[0];
+            }
+        }
+        if(urlMedia === null){
+            if(video.play_addr && video.play_addr.url_list && video.play_addr.url_list.length > 0){
+                urlMedia = video.play_addr.url_list[0];
+            }
+            else{
+                console.error('Error: video download_addr or play_addr or their url_list is missing.');
+            }
+        }
     } else {
-        // download_addr vs play_addr
-        urlMedia = watermark
-            ? res.aweme_list[0].video.download_addr.url_list[0]
-            : res.aweme_list[0].video.play_addr.url_list[0];
+        console.error('Error: video or image_post_info is missing in the aweme object.');
     }
 
     const data = {


### PR DESCRIPTION
There are some videos, where download_addr is missing in a JSON response. So, it will download the video without a watermark in such cases.
Examples of videos:
https://www.tiktok.com/@frogparadise/video/7331753843623054624
https://www.tiktok.com/@georgiiaegan/video/7342410683092454657

